### PR TITLE
chore(ci): test julia 1.10/1.11/1.12 only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,9 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.10'
+          - '1.11'
           - '1.12'
-          - '1.6'
-          - 'pre'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Replaces the 1.12/1.6/pre version matrix with 1.10/1.11/1.12 on ubuntu-latest.