### PR TITLE
ci: add julia-downgrade-compat job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,3 +39,24 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+  downgrade:
+    name: Downgrade Julia ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.10'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-downgrade-compat@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
Adds a `downgrade` job to CI as a sibling of `test`, using `julia-actions/julia-downgrade-compat` to pin every `[compat]` dependency to its lowest allowed version before building and running the test suite.

This verifies the lowest-compatible-version resolve actually builds and tests — the v6/SciMLBase-2 lower corner for the SciML packages (`OrdinaryDiffEq`, `DiffEqBase`, `SciMLOperators`, and the transitive `ModelingToolkit` extension dep). The existing `test` job only exercises the upper corner.

The job mirrors the existing `test` job's action versions (checkout@v4, setup-julia@v2, cache@v2) and runs on the lowest supported Julia (1.10).

Part of DerangedIons/hivemind#1; relates to #2